### PR TITLE
fix: support for unicode characters in role names

### DIFF
--- a/src/saveableState.ts
+++ b/src/saveableState.ts
@@ -1,5 +1,6 @@
 import type { Role } from "./Role";
 import { getHashVars, setHashVars } from "./hashVars";
+import { b64DecodeUnicode, b64EncodeUnicode } from "./utils";
 
 export interface SaveableState {
   roles: Role[];
@@ -7,7 +8,7 @@ export interface SaveableState {
 }
 
 export function saveState(state: SaveableState) {
-  const encoded = btoa(JSON.stringify(state));
+  const encoded = b64EncodeUnicode(JSON.stringify(state));
   const hashVars = getHashVars();
   hashVars.state = encoded;
   setHashVars(hashVars);
@@ -15,5 +16,5 @@ export function saveState(state: SaveableState) {
 
 export function loadState(): SaveableState | null {
   const hashVars = getHashVars();
-  return hashVars.state ? JSON.parse(atob(hashVars.state)) : null;
+  return hashVars.state ? JSON.parse(b64DecodeUnicode(hashVars.state)) : null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,3 +12,22 @@ export function useEffectIgnoreFirstCall(effect: any, deps: any[]) {
     effect();
   }, deps);
 }
+
+export function b64EncodeUnicode(str: string) {
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
+      return String.fromCharCode(parseInt("0x" + p1));
+    }),
+  );
+}
+
+export function b64DecodeUnicode(str: string) {
+  return decodeURIComponent(
+    atob(str)
+      .split("")
+      .map(function (c) {
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join(""),
+  );
+}


### PR DESCRIPTION
Previously, when used any non-latin1 character in role name UI of website crashed, as btoa only supports latin1 characters.
This PR fixes this issue, remaining fully compatible with old btoa links